### PR TITLE
Upgrade Checker Framework dependency to 2.5.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     androidStubs           : "4.1.1.4",
-    checkerFramework       : "2.5.4",
+    checkerFramework       : "2.5.5",
     junit4                 : "4.12",
     rxAndroid2             : "2.0.2",
     rxJava2                : "2.2.0",
@@ -33,7 +33,7 @@ def build = [
 
 def test = [
   androidStubs             : "com.google.android:android:${versions.androidStubs}",
-  checkerframeworkTestlib  : "org.checkerframework:testlib:${versions.checkerFramework}",
+  checkerframeworkTestlib  : "org.checkerframework:framework-test:${versions.checkerFramework}",
   junit4                   : "junit:junit:${versions.junit4}",
 ]
 

--- a/rx-thread-checker/src/test/java/com/ubercab/rxthreadchecker/RxThreadCheckerTest.java
+++ b/rx-thread-checker/src/test/java/com/ubercab/rxthreadchecker/RxThreadCheckerTest.java
@@ -33,9 +33,8 @@ public class RxThreadCheckerTest extends CheckerFrameworkPerDirectoryTest {
         null,
         "-Anomsgtext",
             "-Anocheckjdk",
-            "-AprintErrorStack",
-            //"-AstubWarnIfNotFound",
-            //"-AstubWarnIfNotFoundIgnoresClasses",
+            "-AstubWarnIfNotFound",
+            "-AstubWarnIfNotFoundIgnoresClasses",
             "-Astubs="+testStubString());
   }
 


### PR DESCRIPTION
This gives us anonymous class UI-effect polymorphism inference and the `-AstubWarnIfNotFoundIgnoresClasses` flag.